### PR TITLE
Add rate limit to changefeed error, refine owner rate limit (#713)

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -41,8 +41,7 @@ var ErrSuicide = errors.New("Suicide")
 
 // Capture represents a Capture server, it monitors the changefeed information in etcd and schedules Task on it.
 type Capture struct {
-	pdEndpoints []string
-	etcdClient  kv.CDCEtcdClient
+	etcdClient kv.CDCEtcdClient
 
 	processors map[string]*processor
 	procLock   sync.Mutex
@@ -92,12 +91,11 @@ func NewCapture(ctx context.Context, pdEndpoints []string, advertiseAddr string)
 		zap.String("capture-id", id), zap.String("advertise-addr", advertiseAddr))
 
 	c = &Capture{
-		processors:  make(map[string]*processor),
-		pdEndpoints: pdEndpoints,
-		etcdClient:  cli,
-		session:     sess,
-		election:    elec,
-		info:        info,
+		processors: make(map[string]*processor),
+		etcdClient: cli,
+		session:    sess,
+		election:   elec,
+		info:       info,
 	}
 
 	return

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -16,6 +16,7 @@ package model
 import (
 	"encoding/json"
 	"math"
+	"sort"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -44,6 +45,19 @@ const (
 	StateRemoved FeedState = "removed"
 )
 
+const (
+	// errorHistoryGCInterval represents how long we keep error record in changefeed info
+	errorHistoryGCInterval = time.Minute * 10
+
+	// errorHistoryCheckInterval represents time window for failure check
+	errorHistoryCheckInterval = time.Minute * 2
+
+	// errorHistoryThreshold represents failure upper limit in time window.
+	// Before a changefeed is initialized, check the the failure count of this
+	// changefeed, if it is less than errorHistoryThreshold, then initialize it.
+	errorHistoryThreshold = 5
+)
+
 // ChangeFeedInfo describes the detail of a ChangeFeed
 type ChangeFeedInfo struct {
 	SinkURI    string            `json:"sink-uri"`
@@ -58,9 +72,10 @@ type ChangeFeedInfo struct {
 	Engine       SortEngine   `json:"sort-engine"`
 	SortDir      string       `json:"sort-dir"`
 
-	Config *config.ReplicaConfig `json:"config"`
-	State  FeedState             `json:"state"`
-	Error  *RunningError         `json:"error"`
+	Config   *config.ReplicaConfig `json:"config"`
+	State    FeedState             `json:"state"`
+	ErrorHis []int64               `json:"history"`
+	Error    *RunningError         `json:"error"`
 }
 
 // GetStartTs returns StartTs if it's  specified or using the CreateTime of changefeed.
@@ -135,4 +150,29 @@ func (info *ChangeFeedInfo) VerifyAndFix() error {
 		info.Config.Scheduler = defaultConfig.Scheduler
 	}
 	return nil
+}
+
+// CheckErrorHistory checks error history of a changefeed
+// if having error record older than GC interval, set needSave to true.
+// if error counts reach threshold, set canInit to false.
+func (info *ChangeFeedInfo) CheckErrorHistory() (needSave bool, canInit bool) {
+	i := sort.Search(len(info.ErrorHis), func(i int) bool {
+		ts := info.ErrorHis[i]
+		return time.Since(time.Unix(ts/1e3, (ts%1e3)*1e6)) < errorHistoryGCInterval
+	})
+	if i == len(info.ErrorHis) {
+		info.ErrorHis = info.ErrorHis[:]
+	} else {
+		info.ErrorHis = info.ErrorHis[i:]
+	}
+	if i > 0 {
+		needSave = true
+	}
+
+	i = sort.Search(len(info.ErrorHis), func(i int) bool {
+		ts := info.ErrorHis[i]
+		return time.Since(time.Unix(ts/1e3, (ts%1e3)*1e6)) < errorHistoryCheckInterval
+	})
+	canInit = len(info.ErrorHis)-i < errorHistoryThreshold
+	return
 }

--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -384,6 +384,20 @@ func (o *Owner) loadChangeFeeds(ctx context.Context) error {
 			log.Info("changefeed recovered from failure", zap.String("changefeed", changeFeedID))
 			delete(o.failedFeeds, changeFeedID)
 		}
+		needSave, canInit := cfInfo.CheckErrorHistory()
+		if needSave {
+			err := o.etcdClient.SaveChangeFeedInfo(ctx, cfInfo, changeFeedID)
+			if err != nil {
+				return err
+			}
+		}
+		if !canInit {
+			// avoid too many logs here
+			if time.Now().Unix()%60 == 0 {
+				log.Warn("changefeed fails reach rate limit, try to initialize it later", zap.Int64s("history", cfInfo.ErrorHis))
+			}
+			continue
+		}
 		err = cfInfo.VerifyAndFix()
 		if err != nil {
 			return err
@@ -400,6 +414,13 @@ func (o *Owner) loadChangeFeeds(ctx context.Context) error {
 
 		newCf, err := o.newChangeFeed(ctx, changeFeedID, taskStatus, taskPositions, cfInfo, checkpointTs)
 		if err != nil {
+			cfInfo.Error = &model.RunningError{
+				Addr:    util.CaptureAddrFromCtx(ctx),
+				Code:    "CDC-owner-1001",
+				Message: err.Error(),
+			}
+			cfInfo.ErrorHis = append(cfInfo.ErrorHis, time.Now().UnixNano()/1e6)
+
 			if filter.ChangefeedFastFailError(err) {
 				log.Error("create changefeed with fast fail error, mark changefeed as failed",
 					zap.Error(err), zap.String("changefeedid", changeFeedID))
@@ -409,6 +430,11 @@ func (o *Owner) loadChangeFeeds(ctx context.Context) error {
 					return err
 				}
 				continue
+			}
+
+			err2 := o.etcdClient.SaveChangeFeedInfo(ctx, cfInfo, changeFeedID)
+			if err2 != nil {
+				return err2
 			}
 			return errors.Annotatef(err, "create change feed %s", changeFeedID)
 		}
@@ -602,6 +628,7 @@ func (o *Owner) handleAdminJob(ctx context.Context) error {
 
 			cf.info.AdminJobType = model.AdminStop
 			cf.info.Error = job.Error
+			cf.info.ErrorHis = append(cf.info.ErrorHis, time.Now().UnixNano()/1e6)
 			err := o.etcdClient.SaveChangeFeedInfo(ctx, cf.info, job.CfID)
 			if err != nil {
 				return errors.Trace(err)
@@ -1049,11 +1076,15 @@ func (o *Owner) rebuildCaptureEvents(ctx context.Context, captures []*model.Capt
 func (o *Owner) startCaptureWatcher(ctx context.Context) {
 	log.Info("start to watch captures")
 	go func() {
-		rl := rate.NewLimiter(0.05, 5)
+		rl := rate.NewLimiter(0.05, 2)
 		for {
-			if !rl.Allow() {
-				log.Error("owner capture watcher exceeds rate limit")
-				time.Sleep(10 * time.Second)
+			err := rl.Wait(ctx)
+			if err != nil {
+				if errors.Cause(err) == context.Canceled {
+					return
+				}
+				log.Error("capture watcher wait limit token error", zap.Error(err))
+				return
 			}
 			if err := o.watchCapture(ctx); err != nil {
 				// When the watching routine returns, the error must not

--- a/cdc/task_test.go
+++ b/cdc/task_test.go
@@ -49,10 +49,9 @@ func (s *taskSuite) SetUpTest(c *check.C) {
 
 	// Create a task watcher
 	capture := &Capture{
-		pdEndpoints: s.endpoints,
-		etcdClient:  kv.NewCDCEtcdClient(client),
-		processors:  make(map[string]*processor),
-		info:        &model.CaptureInfo{ID: "task-suite-capture", AdvertiseAddr: "task-suite-addr"},
+		etcdClient: kv.NewCDCEtcdClient(client),
+		processors: make(map[string]*processor),
+		info:       &model.CaptureInfo{ID: "task-suite-capture", AdvertiseAddr: "task-suite-addr"},
 	}
 	c.Assert(capture, check.NotNil)
 	watcher := NewTaskWatcher(capture, &TaskWatcherConfig{
@@ -76,10 +75,9 @@ func (s *taskSuite) TestNewTaskWatcher(c *check.C) {
 	// initialize the PD service witch does not support to
 	// be embeded.
 	capture := &Capture{
-		pdEndpoints: s.endpoints,
-		etcdClient:  kv.NewCDCEtcdClient(s.c),
-		processors:  make(map[string]*processor),
-		info:        &model.CaptureInfo{ID: "task-suite-capture", AdvertiseAddr: "task-suite-addr"},
+		etcdClient: kv.NewCDCEtcdClient(s.c),
+		processors: make(map[string]*processor),
+		info:       &model.CaptureInfo{ID: "task-suite-capture", AdvertiseAddr: "task-suite-addr"},
 	}
 	c.Assert(capture, check.NotNil)
 	c.Assert(NewTaskWatcher(capture, &TaskWatcherConfig{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-cdc/cdc-ansible`

### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
